### PR TITLE
Override hashCode getter

### DIFF
--- a/lib/range.dart
+++ b/lib/range.dart
@@ -24,6 +24,14 @@ class Range extends Object with IterableMixin<int> {
 
   bool get isEmpty => length == 0;
 
+  int get hashCode {
+    int result = 17;
+    result = 37 * result + start.hashCode;
+    result = 37 * result + stop.hashCode;
+    result = 37 * result + step.hashCode;
+    return result;
+  }
+
   String toString() {
     return step == 1 ?
       "Range($start, $stop)" : "Range($start, $stop, $step)";

--- a/test/range_test.dart
+++ b/test/range_test.dart
@@ -135,6 +135,16 @@ main() {
     }
   });
 
+  test("hashCode", () {
+    expect(range(1, 2, 3).hashCode, range(1, 2, 3).hashCode);
+    expect(range(1, 2).hashCode, range(1, 2).hashCode);
+    expect(range(1).hashCode, range(1).hashCode);
+    expect(range(1, 2, 3).hashCode, isNot(equals(range(1, 0, 3).hashCode)));
+    expect(range(1, 2, 3).hashCode, isNot(equals(range(0, 2, 3).hashCode)));
+    expect(range(1, 2, 3).hashCode, isNot(equals(range(1, 2).hashCode)));
+    expect(range(1, 1).hashCode, isNot(equals(range(2, 2).hashCode)));
+  });
+
   test("operator ==", () {
     expect(range(1, 2, 3)==range(1, 2, 3), true);
     expect(range(1, 2, 3)==range(1, 0, 3), false);


### PR DESCRIPTION
Overrides the hashCode getter to silence the warning range generated while building.

```
packages/range/range.dart:74:17: Hint: The class 'Range' overrides 'operator==', but not 'get hashCode'.
  bool operator ==(Range other) {
                ^^
```

Implemented according to https://www.dartlang.org/docs/dart-up-and-running/contents/ch03.html
