### PR TITLE
Fix == operator of Range.

### DIFF
--- a/lib/range.dart
+++ b/lib/range.dart
@@ -74,12 +74,10 @@ class Range extends Object with IterableMixin<int> {
     return l;
   }
 
-  bool operator ==(Range other) {
-    return (other != null &&
-        start == other.start &&
-        stop == other.stop &&
-        step == other.step);
-  }
+  bool operator ==(other) => other is Range &&
+      start == other.start &&
+      stop == other.stop &&
+      step == other.step;
 
   final int start;
   final int stop;

--- a/test/range_test.dart
+++ b/test/range_test.dart
@@ -135,6 +135,16 @@ main() {
     }
   });
 
+  test("==", () {
+    var r = range(1, 8, 2);
+    expect(r == null, isFalse);
+    expect(r == 'hi', isFalse);
+    expect(r == range(1, 8, 2), isTrue);
+    expect(r == range(1, 8, 4), isFalse);
+    expect(r == range(2, 8, 2), isFalse);
+    expect(r == range(1, 7, 2), isFalse);
+  });
+
   test("hashCode", () {
     expect(range(1, 2, 3).hashCode, range(1, 2, 3).hashCode);
     expect(range(1, 2).hashCode, range(1, 2).hashCode);


### PR DESCRIPTION
== operator must check if other is of Range type. Otherwise,
`range(1, 2, 3) == 'hi'` throws an Error.