### PR TITLE
Use package: import in test

### DIFF
--- a/test/range_test.dart
+++ b/test/range_test.dart
@@ -1,4 +1,4 @@
-import '../lib/range.dart';
+import 'package:range/range.dart';
 import 'package:test/test.dart';
 
 main() {


### PR DESCRIPTION
In keeping with best practices, use package: imports when importing a
package's lib/ sources, and reserve relative imports for imports of
files within lib/ importing files within lib/.